### PR TITLE
Chore: Public token tiers sstate variable

### DIFF
--- a/contracts/Karmic.sol
+++ b/contracts/Karmic.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "./Badger.sol";
 
 contract Karmic is Badger{
-    mapping(address => uint256) private boxTokenTiers;
+    mapping(address => uint256) public boxTokenTiers;
     uint256 boxTokenCounter;
 
     constructor(string memory _newBaseUri) Badger(_newBaseUri) {}

--- a/deploy/00_deploy_karmic.js
+++ b/deploy/00_deploy_karmic.js
@@ -2,7 +2,7 @@ const deployFunction = async ({ getSigners, deployments, ethers }) => {
   const { deploy } = deployments;
   const [deployer] = await ethers.getSigners();
 
-  const baseUri = "www.sphere.com/";
+  const baseUri = "http://localhost:3000/";
 
   await deploy("Karmic", {
     from: deployer.address,

--- a/tasks/prepareForTesting.js
+++ b/tasks/prepareForTesting.js
@@ -2,13 +2,13 @@ const { task } = require("hardhat/config");
 const { ethers } = require("ethers");
 
 /*
-  deploys three test tokens
+  deploys six test tokens
   mints 1000 units of two test token to address of recipient
   adds token addresses to karmic 
 */
 
 const TOTAL_TOKENS = 6;
-const TOKENS = 5;
+const TOKENS = 2;
 const AMOUNT = ethers.utils.parseEther("1000");
 
 task("prepare", "Prepares")
@@ -33,7 +33,7 @@ task("prepare", "Prepares")
       }
 
       boxTokenAddresses.push(boxTokenInstance.address);
-      boxTokenMetadataUris.push(`meta${i + 1}`);
+      boxTokenMetadataUris.push(`metadata.json`);
     }
 
     await karmicInstance.addBoxTokens(boxTokenAddresses, boxTokenMetadataUris);


### PR DESCRIPTION
**SQ**
- tokenTiers is private
- the dapp must be able to get the tokenId of a boxToken, so that it can retrieve the metadata for that box token (to display the image)

**AC**
- tokenTiers is public

connected to https://github.com/thesphere/karmic-dapp/pull/8